### PR TITLE
🪲 Add debug markers and fix device selection

### DIFF
--- a/ArtifactVK/App.cpp
+++ b/ArtifactVK/App.cpp
@@ -14,7 +14,7 @@ const InstanceCreateInfo DefaultCreateInfo()
     createInfo.Name = "ArtifactVK";
     createInfo.ValidationLayers =
         std::vector<ValidationLayer>{ValidationLayer{EValidationLayer::KhronosValidation, false}};
-    createInfo.RequiredExtensions = std::vector<EDeviceExtension>{EDeviceExtension::VkSwapchain};
+    createInfo.RequiredExtensions = std::vector<EDeviceExtension>{EDeviceExtension::Swapchain};
     return createInfo;
 }
 

--- a/ArtifactVK/ArtifactVK.vcxproj
+++ b/ArtifactVK/ArtifactVK.vcxproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <ClCompile Include="App.cpp" />
     <ClCompile Include="backend\Barrier.cpp" />
+    <ClCompile Include="backend\DebugMarker.cpp" />
     <ClCompile Include="backend\DeviceExtensionMapping.cpp" />
     <ClCompile Include="backend\Framebuffer.cpp" />
     <ClCompile Include="backend\CommandBufferPool.cpp" />
@@ -123,6 +124,7 @@
   <ItemGroup>
     <ClInclude Include="App.h" />
     <ClInclude Include="backend\DescriptorSetBuilder.h" />
+    <ClInclude Include="backend\DebugMarker.h" />
     <ClInclude Include="Image.h" />
     <ClInclude Include="backend\PhysicalDevice.h" />
     <ClInclude Include="backend\Queue.h" />

--- a/ArtifactVK/backend/CommandBufferPool.cpp
+++ b/ArtifactVK/backend/CommandBufferPool.cpp
@@ -389,6 +389,7 @@ void CommandBuffer::Reset()
     vkResetCommandBuffer(m_CommandBuffer, 0);
     if (m_Name)
     {
+        // Reset tends to reset the name as well.
         SetName(*m_Name, *m_ExtensionFunctionMapping);
     }
     m_Status = CommandBufferStatus::Reset;

--- a/ArtifactVK/backend/CommandBufferPool.h
+++ b/ArtifactVK/backend/CommandBufferPool.h
@@ -64,6 +64,8 @@ class CommandBuffer
     void HandleAcquire(DeviceBuffer &buffer);
     void Reset();
 
+    // Only used in case we Reset, which can clear a debug name previously
+    // set.
     std::optional<std::string> m_Name;
     std::optional<std::reference_wrapper<const ExtensionFunctionMapping>> m_ExtensionFunctionMapping;
     bool m_Moved = false;

--- a/ArtifactVK/backend/CommandBufferPool.h
+++ b/ArtifactVK/backend/CommandBufferPool.h
@@ -20,6 +20,7 @@ class DeviceBuffer;
 class IndexBuffer;
 class DescriptorSet;
 class ExtensionFunctionMapping;
+class VulkanInstance;
 
 struct CommandBufferPoolCreateInfo
 {
@@ -63,6 +64,8 @@ class CommandBuffer
     void HandleAcquire(DeviceBuffer &buffer);
     void Reset();
 
+    std::optional<std::string> m_Name;
+    std::optional<std::reference_wrapper<const ExtensionFunctionMapping>> m_ExtensionFunctionMapping;
     bool m_Moved = false;
     VkDevice m_Device;
     VkCommandBuffer m_CommandBuffer;
@@ -84,14 +87,16 @@ class CommandBuffer
 class CommandBufferPool
 {
   public:
-    CommandBufferPool(VkDevice device, CommandBufferPoolCreateInfo createInfo);
+    CommandBufferPool(VkDevice device, CommandBufferPoolCreateInfo createInfo, const VulkanInstance& instance);
     CommandBufferPool(const CommandBufferPool &other) = delete;
     CommandBufferPool(CommandBufferPool &&other);
     ~CommandBufferPool();
     
     std::vector<std::reference_wrapper<CommandBuffer>> CreateCommandBuffers(uint32_t count, Queue queue);
     CommandBuffer& CreateCommandBuffer(Queue queue);
+    void SetName(const std::string& name, ExtensionFunctionMapping mapping);
   private:
+    const VulkanInstance &m_Instance;
     VkDevice m_Device;
     VkCommandPool m_CommandBufferPool;
     // TODO: Cleanup command buffers

--- a/ArtifactVK/backend/CommandBufferPool.h
+++ b/ArtifactVK/backend/CommandBufferPool.h
@@ -4,6 +4,7 @@
 #include <span>
 #include <functional>
 #include <memory>
+#include <string>
 
 #include "Semaphore.h"
 #include "Fence.h"
@@ -18,13 +19,13 @@ class UniformBuffer;
 class DeviceBuffer;
 class IndexBuffer;
 class DescriptorSet;
+class ExtensionFunctionMapping;
 
 struct CommandBufferPoolCreateInfo
 {
     VkCommandPoolCreateFlagBits CreationFlags;
     uint32_t QueueIndex;
 };
-
 
 class CommandBuffer
 {
@@ -38,8 +39,10 @@ class CommandBuffer
   public:
     CommandBuffer(VkCommandBuffer &&commandBuffer, VkDevice device, Queue queue);
     CommandBuffer(CommandBuffer && other);
+    CommandBuffer(const CommandBuffer & other) = delete;
     ~CommandBuffer();
 
+    void SetName(const std::string& name, const ExtensionFunctionMapping& functionMapping);
     void WaitFence();
     void Begin();
     void BeginSingleTake();
@@ -61,6 +64,7 @@ class CommandBuffer
     void Reset();
 
     bool m_Moved = false;
+    VkDevice m_Device;
     VkCommandBuffer m_CommandBuffer;
     // TODO: Pool these fences in the CommandBufferPool
     // This is a shared ptr so that the fence can outlive (the ArtifactVK

--- a/ArtifactVK/backend/DebugMarker.cpp
+++ b/ArtifactVK/backend/DebugMarker.cpp
@@ -1,22 +1,43 @@
 #include "DebugMarker.h"
 
 #include <string>
+#include <stdexcept>
 
 void DebugMarker::SetName(VkDevice device, const ExtensionFunctionMapping &extensionMapper, VkCommandBuffer handle,
                           const std::string &name)
 {
-    auto setNameFn = (PFN_vkSetDebugUtilsObjectNameEXT)extensionMapper.GetFunction(EExtensionFunction::DebugUtilsSetObjectName);
-
-    auto info = GetDebugObjectName(name);
-    info.objectType = VkObjectType::VK_OBJECT_TYPE_COMMAND_BUFFER;
-    info.objectHandle = reinterpret_cast<uint64_t>(handle);
-    setNameFn(device, &info);
+    SetNameInternal(name, extensionMapper, device, reinterpret_cast<uint64_t>(handle), VkObjectType::VK_OBJECT_TYPE_COMMAND_BUFFER);
 }
 
-VkDebugUtilsObjectNameInfoEXT DebugMarker::GetDebugObjectName(const std::string& name)
+void DebugMarker::SetName(VkDevice device, const ExtensionFunctionMapping &extensionMapper, VkDescriptorSet handle,
+                          const std::string &name)
 {
-    return VkDebugUtilsObjectNameInfoEXT{.sType = VkStructureType::VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT,
+
+    SetNameInternal(name, extensionMapper, device, reinterpret_cast<uint64_t>(handle), VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET);
+    
+}
+
+void DebugMarker::SetName(VkDevice device, const ExtensionFunctionMapping &extensionMapper, VkCommandPool handle,
+                          const std::string &name)
+{
+    SetNameInternal(name, extensionMapper, device, reinterpret_cast<uint64_t>(handle), VkObjectType::VK_OBJECT_TYPE_COMMAND_POOL);
+}
+
+void DebugMarker::SetNameInternal(const std::string& name, const ExtensionFunctionMapping& mapping, VkDevice device,
+    uint64_t handle, VkObjectType handleType)
+{
+    auto setNameFn = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
+        mapping.GetFunction(EExtensionFunction::DebugUtilsSetObjectName));
+    auto info = VkDebugUtilsObjectNameInfoEXT{.sType = VkStructureType::VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
                                           .pNext = nullptr,
-                                          .pObjectName = name.c_str()};
+                                         .objectType = handleType,
+                                         .objectHandle = handle,
+                                         .pObjectName = name.c_str()
+    };
+
+    if (setNameFn(device, &info) != VkResult::VK_SUCCESS)
+    {
+        throw std::runtime_error("Could not set name");
+    }
 }
 

--- a/ArtifactVK/backend/DebugMarker.cpp
+++ b/ArtifactVK/backend/DebugMarker.cpp
@@ -1,0 +1,22 @@
+#include "DebugMarker.h"
+
+#include <string>
+
+void DebugMarker::SetName(VkDevice device, const ExtensionFunctionMapping &extensionMapper, VkCommandBuffer handle,
+                          const std::string &name)
+{
+    auto setNameFn = (PFN_vkSetDebugUtilsObjectNameEXT)extensionMapper.GetFunction(EExtensionFunction::DebugUtilsSetObjectName);
+
+    auto info = GetDebugObjectName(name);
+    info.objectType = VkObjectType::VK_OBJECT_TYPE_COMMAND_BUFFER;
+    info.objectHandle = reinterpret_cast<uint64_t>(handle);
+    setNameFn(device, &info);
+}
+
+VkDebugUtilsObjectNameInfoEXT DebugMarker::GetDebugObjectName(const std::string& name)
+{
+    return VkDebugUtilsObjectNameInfoEXT{.sType = VkStructureType::VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT,
+                                          .pNext = nullptr,
+                                          .pObjectName = name.c_str()};
+}
+

--- a/ArtifactVK/backend/DebugMarker.h
+++ b/ArtifactVK/backend/DebugMarker.h
@@ -10,7 +10,12 @@ class DebugMarker
   public:
     static void SetName(VkDevice vkDevice, const ExtensionFunctionMapping &extensionMapper, VkCommandBuffer handle, 
         const std::string& name);
+    static void SetName(VkDevice vkDevice, const ExtensionFunctionMapping &extensionMapper, VkDescriptorSet handle, 
+        const std::string& name);
+    static void SetName(VkDevice vkDevice, const ExtensionFunctionMapping &extensionMapper, VkCommandPool handle, 
+        const std::string& name);
 
   private:
-    static VkDebugUtilsObjectNameInfoEXT GetDebugObjectName(const std::string& name);
+    static void SetNameInternal(const std::string& name, const ExtensionFunctionMapping& mapping, VkDevice device,
+        uint64_t handle, VkObjectType handleType);
 };

--- a/ArtifactVK/backend/DebugMarker.h
+++ b/ArtifactVK/backend/DebugMarker.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vulkan/vulkan.h>
+
+#include <string>
+
+#include "ExtensionFunctionMapping.h"
+
+class DebugMarker
+{
+  public:
+    static void SetName(VkDevice vkDevice, const ExtensionFunctionMapping &extensionMapper, VkCommandBuffer handle, 
+        const std::string& name);
+
+  private:
+    static VkDebugUtilsObjectNameInfoEXT GetDebugObjectName(const std::string& name);
+};

--- a/ArtifactVK/backend/DescriptorPool.h
+++ b/ArtifactVK/backend/DescriptorPool.h
@@ -12,7 +12,7 @@ class DescriptorSetLayout;
 
 struct DescriptorPoolCreateInfo
 {
-    uint32_t SizePerType = 32;
+    uint32_t SizePerType = 4;
     // TODO: Convert to custom flags to prevent allocations
     std::vector<VkDescriptorType> Types;
 };

--- a/ArtifactVK/backend/DescriptorPool.h
+++ b/ArtifactVK/backend/DescriptorPool.h
@@ -12,7 +12,7 @@ class DescriptorSetLayout;
 
 struct DescriptorPoolCreateInfo
 {
-    uint32_t SizePerType = 4;
+    uint32_t SizePerType = 32;
     // TODO: Convert to custom flags to prevent allocations
     std::vector<VkDescriptorType> Types;
 };

--- a/ArtifactVK/backend/DescriptorSetBuilder.cpp
+++ b/ArtifactVK/backend/DescriptorSetBuilder.cpp
@@ -3,6 +3,7 @@
 #include "UniformBuffer.h"
 #include "Texture.h"
 #include "DescriptorPool.h"
+#include "DebugMarker.h"
 
 BindSet::BindSet(const DescriptorSet &descriptorSet, VkDevice device) : 
     m_DescriptorSet(descriptorSet),
@@ -77,6 +78,11 @@ VkDescriptorSet DescriptorSet::Get() const
 const DescriptorSetLayout& DescriptorSet::GetLayout() const
 {
     return m_Layout;
+}
+
+void DescriptorSet::SetName(const std::string &name, const ExtensionFunctionMapping& mapping)
+{
+    DebugMarker::SetName(m_Device, mapping, m_DescriptorSet, name);
 }
 
 DescriptorSet::DescriptorSet(const DescriptorSetLayout &layout, VkDevice device, VkDescriptorSet set)

--- a/ArtifactVK/backend/DescriptorSetBuilder.h
+++ b/ArtifactVK/backend/DescriptorSetBuilder.h
@@ -8,6 +8,7 @@ class UniformBuffer;
 class Texture;
 class DescriptorPool;
 class DescriptorSet;
+class ExtensionFunctionMapping;
 
 class BindSet
 {
@@ -58,6 +59,7 @@ class DescriptorSet
     BindSet BindUniformBuffer(const UniformBuffer& buffer);
     VkDescriptorSet Get() const;
     const DescriptorSetLayout& GetLayout() const;
+    void SetName(const std::string &name, const ExtensionFunctionMapping& mapping);
   private:
     const DescriptorSetLayout& m_Layout;
     VkDevice m_Device;

--- a/ArtifactVK/backend/DeviceExtensionMapping.cpp
+++ b/ArtifactVK/backend/DeviceExtensionMapping.cpp
@@ -40,5 +40,5 @@ std::vector<const char *> DeviceExtensionMapping::ReverseMap(std::span<const EDe
 
 std::unordered_map<std::string_view, EDeviceExtension> DeviceExtensionMapping::CreateNameMapping()
 {
-    return {{VK_KHR_SWAPCHAIN_EXTENSION_NAME, EDeviceExtension::VkSwapchain}};
+    return {{VK_KHR_SWAPCHAIN_EXTENSION_NAME, EDeviceExtension::Swapchain}};
 }

--- a/ArtifactVK/backend/DeviceExtensionMapping.h
+++ b/ArtifactVK/backend/DeviceExtensionMapping.h
@@ -5,7 +5,7 @@
 
 enum class EDeviceExtension
 {
-    VkSwapchain,
+    Swapchain,
     Unknown
 };
 

--- a/ArtifactVK/backend/ExtensionFunctionMapping.cpp
+++ b/ArtifactVK/backend/ExtensionFunctionMapping.cpp
@@ -8,8 +8,9 @@ ExtensionFunctionMapping::ExtensionFunctionMapping(const VkInstance &vkInstance)
 std::unordered_map<EExtensionFunction, const char *> ExtensionFunctionMapping::CreateFunctionNameMapping() const
 {
     std::unordered_map<EExtensionFunction, const char *> nameMapping;
-    nameMapping.insert({EExtensionFunction::VkCreateDebugUtilsMessengerExt, "vkCreateDebugUtilsMessengerEXT"});
-    nameMapping.insert({EExtensionFunction::VkDestroyDebugUtilsMessengerEXT, "vkDestroyDebugUtilsMessengerEXT"});
+    nameMapping.insert({EExtensionFunction::CreateDebugUtilsMessenger, "vkCreateDebugUtilsMessengerEXT"});
+    nameMapping.insert({EExtensionFunction::DestroyDebugUtilsMessenger, "vkDestroyDebugUtilsMessengerEXT"});
+    nameMapping.insert({EExtensionFunction::DebugUtilsSetObjectName, "vkSetDebugUtilsObjectNameEXT"});
     return nameMapping;
 }
 

--- a/ArtifactVK/backend/ExtensionFunctionMapping.h
+++ b/ArtifactVK/backend/ExtensionFunctionMapping.h
@@ -4,10 +4,13 @@
 
 enum class EExtensionFunction
 {
-    VkCreateDebugUtilsMessengerExt,
-    VkDestroyDebugUtilsMessengerEXT
+    CreateDebugUtilsMessenger,
+    DestroyDebugUtilsMessenger,
+    DebugUtilsSetObjectName
 };
 
+// TODO: Automatically bind requested extensions through DeviceExtensionMapping to the matching functions
+// TODO: Replace with volk?
 class ExtensionFunctionMapping
 {
   public:

--- a/ArtifactVK/backend/PhysicalDevice.cpp
+++ b/ArtifactVK/backend/PhysicalDevice.cpp
@@ -47,9 +47,10 @@ std::vector<EDeviceExtension> PhysicalDevice::FilterAvailableExtensions(
 }
 
 VulkanDevice PhysicalDevice::CreateLogicalDevice(const std::vector<const char *> &validationLayers,
-                                                      std::vector<EDeviceExtension> extensions, GLFWwindow& window)
+                                                 std::vector<EDeviceExtension> extensions, GLFWwindow &window,
+                                                 const VulkanInstance &instance)
 {
-    return VulkanDevice(*this, m_PhysicalDevice, validationLayers, extensions, m_ExtensionMapping, window);
+    return VulkanDevice(*this, m_PhysicalDevice, instance, validationLayers, extensions, m_ExtensionMapping, window);
 }
 
 SurfaceProperties PhysicalDevice::GetCachedSurfaceProperties() const
@@ -128,7 +129,7 @@ std::set<EDeviceExtension> PhysicalDevice::QueryExtensions(const DeviceExtension
     uint32_t extensionCount;
     // TODO: Embed support for layer-based extensions
     vkEnumerateDeviceExtensionProperties(m_PhysicalDevice, nullptr, &extensionCount, nullptr);
-    std::vector<VkExtensionProperties> extensions(extensionCount);
+    std::vector<VkExtensionProperties> extensions(extensionCount, VkExtensionProperties{});
     vkEnumerateDeviceExtensionProperties(m_PhysicalDevice, nullptr, &extensionCount, extensions.data());
 
     std::set<EDeviceExtension> mappedExtensions;

--- a/ArtifactVK/backend/PhysicalDevice.h
+++ b/ArtifactVK/backend/PhysicalDevice.h
@@ -32,8 +32,9 @@ class PhysicalDevice
     const VkPhysicalDeviceProperties& GetProperties() const;
     const VkPhysicalDeviceFeatures& GetFeatures() const;
     std::vector<EDeviceExtension> FilterAvailableExtensions(std::span<const EDeviceExtension> desiredExtensions) const;
-    VulkanDevice CreateLogicalDevice(const std::vector<const char *>& validationLayers,
-                                            std::vector<EDeviceExtension> extensions, GLFWwindow& window);
+    VulkanDevice CreateLogicalDevice(const std::vector<const char *> &validationLayers,
+                                                 std::vector<EDeviceExtension> extensions, GLFWwindow &window,
+                                                 const VulkanInstance &instance);
 
     // TODO: These are the cached values, but not neccessarily the latest. Need to requery this possibly
     SurfaceProperties GetCachedSurfaceProperties() const;

--- a/ArtifactVK/backend/Pipeline.h
+++ b/ArtifactVK/backend/Pipeline.h
@@ -15,7 +15,7 @@ class UniformBuffer;
 
 struct PipelineCreateInfo
 {
-    VkGraphicsPipelineCreateInfo CreateInfo;
+    VkGraphicsPipelineCreateInfo CreateInfo{};
     std::vector<VkDescriptorSetLayout> Descriptors;
     const RenderPass &RenderPass;
 };

--- a/ArtifactVK/backend/VulkanDebugMessenger.cpp
+++ b/ArtifactVK/backend/VulkanDebugMessenger.cpp
@@ -46,7 +46,7 @@ VulkanDebugMessenger::~VulkanDebugMessenger()
     if (m_DebugMessenger != VK_NULL_HANDLE)
     {
         auto destroyDebugManager = (PFN_vkDestroyDebugUtilsMessengerEXT)m_ExtensionMapper.GetFunction(
-            EExtensionFunction::VkDestroyDebugUtilsMessengerEXT);
+            EExtensionFunction::DestroyDebugUtilsMessenger);
         destroyDebugManager(m_VulkanInstance, m_DebugMessenger, nullptr);
     }
 }
@@ -76,7 +76,7 @@ VkDebugUtilsMessengerEXT VulkanDebugMessenger::Create(VkInstance &vulkanInstance
                                                       const ExtensionFunctionMapping &extensionMapper)
 {
     auto createFunction = (PFN_vkCreateDebugUtilsMessengerEXT)extensionMapper.GetFunction(
-        EExtensionFunction::VkCreateDebugUtilsMessengerExt);
+        EExtensionFunction::CreateDebugUtilsMessenger);
     VkDebugUtilsMessengerEXT debugMessenger;
     auto createInfo = CreateInfo();
     // TODO: Handle errors here

--- a/ArtifactVK/backend/VulkanDevice.cpp
+++ b/ArtifactVK/backend/VulkanDevice.cpp
@@ -272,6 +272,7 @@ VulkanDevice::VulkanDevice(PhysicalDevice &physicalDevice, VkPhysicalDevice phys
 
     VkDeviceCreateInfo deviceCreateInfo{};
     deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    deviceCreateInfo.pNext = nullptr;
     deviceCreateInfo.pQueueCreateInfos = queueCreateInfos.data();
     deviceCreateInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
     // Also specify here for backwards compatability with old vulkan implementations.
@@ -304,8 +305,8 @@ VulkanDevice::VulkanDevice(PhysicalDevice &physicalDevice, VkPhysicalDevice phys
     m_TransferQueue = Queue(m_Device, physicalDevice.GetQueueFamilies().TransferFamilyIndex.value());
     
     m_TransferCommandBufferPool = m_CommandBufferPools.emplace_back(std::make_unique<CommandBufferPool>(CreateTransferCommandBufferPool())).get();
-    // Arbitrary size
     m_DescriptorPool = std::make_unique<DescriptorPool>(
+        // Arbitrary size
         m_Device, DescriptorPoolCreateInfo{64, {VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER}});
 }
 

--- a/ArtifactVK/backend/VulkanDevice.h
+++ b/ArtifactVK/backend/VulkanDevice.h
@@ -29,11 +29,13 @@ struct GLFWwindow;
 class ShaderModule;
 struct WindowResizeEvent;
 class IndexBuffer;
+class VulkanInstance;
 
 class VulkanDevice
 {
   public:
-    VulkanDevice(PhysicalDevice &physicalDevice, const VkPhysicalDevice &physicalDeviceHandle,
+    VulkanDevice(PhysicalDevice &physicalDevice, VkPhysicalDevice physicalDeviceHandle,
+                        const VulkanInstance& instance,
                         const std::vector<const char *> &validationLayers, std::vector<EDeviceExtension> extensions,
                         const DeviceExtensionMapping &deviceExtensionMapping, GLFWwindow& window);
     VulkanDevice(const VulkanDevice &other) = delete;
@@ -86,6 +88,7 @@ class VulkanDevice
     VkExtent2D SelectSwapchainExtent(GLFWwindow& window, const SurfaceProperties& surfaceProperties) const;
 
     VkDevice m_Device;
+    const VulkanInstance &m_Instance;
     GLFWwindow &m_Window;
     PhysicalDevice &m_PhysicalDevice;
     std::optional<Queue> m_GraphicsQueue;

--- a/ArtifactVK/backend/VulkanInstance.cpp
+++ b/ArtifactVK/backend/VulkanInstance.cpp
@@ -159,10 +159,8 @@ VkInstance VulkanInstance::CreateInstance(const InstanceCreateInfo &createInfo)
     {
         requestedExtensions[i] = glfwExtensions[i];
     }
-    if (!m_ValidationLayers.empty())
-    {
-        requestedExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    }
+    // Required for things like debug markers
+    requestedExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
     uint32_t availableExtensionCount = 0;
     vkEnumerateInstanceExtensionProperties(nullptr, &availableExtensionCount, nullptr);

--- a/ArtifactVK/backend/VulkanInstance.cpp
+++ b/ArtifactVK/backend/VulkanInstance.cpp
@@ -260,7 +260,10 @@ PhysicalDevice VulkanInstance::CreatePhysicalDevice(const VulkanSurface &targetS
     {
         if (iter->IsValid())
         {
-            firstValid = iter;
+            if (numValidDevices == 0)
+            {
+                firstValid = iter;
+            }
             numValidDevices++;
         }
     }

--- a/ArtifactVK/backend/VulkanInstance.h
+++ b/ArtifactVK/backend/VulkanInstance.h
@@ -63,7 +63,7 @@ class VulkanInstance
     VulkanInstance(VulkanInstance &&other);
 
     VulkanDevice &GetActiveDevice();
-
+    const ExtensionFunctionMapping &GetExtensionFunctionMapping() const; 
   private:
     static std::vector<const char *> CheckValidationLayers(const std::vector<ValidationLayer> &validationLayers);
     VkDebugUtilsMessengerEXT CreateDebugMessenger() const;


### PR DESCRIPTION
Adds debug markers for command buffers (does not work in RenderDoc), command buffer pools and descriptor sets.

Also fixes an issue with device selection, where it was using the _last_ device that was suitable, rather than the first.