### PR TITLE
⌚ Fix command buffer wait and improve namings

### DIFF
--- a/ArtifactVK/backend/CommandBufferPool.cpp
+++ b/ArtifactVK/backend/CommandBufferPool.cpp
@@ -443,8 +443,7 @@ std::vector<std::reference_wrapper<CommandBuffer>> CommandBufferPool::CreateComm
     std::vector<std::reference_wrapper<CommandBuffer>> commandBufferHandles;
     for (auto&& vkCommandBuffer : commandBuffers)
     {
-        auto& commandBuffer = commandBufferHandles.emplace_back(*m_CommandBuffers.emplace_back(std::make_unique<CommandBuffer>(std::move(vkCommandBuffer), m_Device, queue)));
-        commandBuffer.get().SetName("Hello, Name", m_Instance.GetExtensionFunctionMapping());
+        commandBufferHandles.emplace_back(*m_CommandBuffers.emplace_back(std::make_unique<CommandBuffer>(std::move(vkCommandBuffer), m_Device, queue)));
     }
 
     return commandBufferHandles;

--- a/ArtifactVK/backend/CommandBufferPool.cpp
+++ b/ArtifactVK/backend/CommandBufferPool.cpp
@@ -418,6 +418,10 @@ CommandBufferPool::CommandBufferPool(CommandBufferPool &&other) :
 
 CommandBufferPool::~CommandBufferPool()
 {
+    for (auto& commandBuffer : m_CommandBuffers)
+    {
+        commandBuffer->WaitFence();
+    }
     vkDestroyCommandPool(m_Device, m_CommandBufferPool, nullptr);
 }
 

--- a/ArtifactVK/backend/CommandBufferPool.cpp
+++ b/ArtifactVK/backend/CommandBufferPool.cpp
@@ -21,7 +21,7 @@
 CommandBuffer::CommandBuffer(VkCommandBuffer &&commandBuffer, VkDevice device, Queue queue) : 
     m_CommandBuffer(commandBuffer), 
     // Start the Fence signaled so that we can query for correct usage prior to beginning the command buffer (again)
-    m_InFlight(std::make_shared<Fence>(device)), m_Queue(queue),
+    m_InFlight(std::make_unique<Fence>(device)), m_Queue(queue),
     m_Device(device)
 {
 }
@@ -163,7 +163,7 @@ void CommandBuffer::DrawIndexed(const Framebuffer& frameBuffer, const RenderPass
 }
 
 // TODO: Bind command buffer to a queue at creation time
-std::shared_ptr<Fence> CommandBuffer::End(std::span<Semaphore> waitSemaphores, std::span<Semaphore> signalSemaphores)
+Fence& CommandBuffer::End(std::span<Semaphore> waitSemaphores, std::span<Semaphore> signalSemaphores)
 {
     if (vkEndCommandBuffer(m_CommandBuffer) != VK_SUCCESS)
     {
@@ -210,10 +210,10 @@ std::shared_ptr<Fence> CommandBuffer::End(std::span<Semaphore> waitSemaphores, s
         throw std::runtime_error("Faied to submit cmd buffer to queue");
     }
     m_Status = CommandBufferStatus::Submitted;
-    return m_InFlight;
+    return *m_InFlight;
 }
 
-std::shared_ptr<Fence> CommandBuffer::End()
+Fence& CommandBuffer::End()
 {
     return End(std::span<Semaphore>(), std::span<Semaphore>());
 }

--- a/ArtifactVK/backend/CommandBufferPool.h
+++ b/ArtifactVK/backend/CommandBufferPool.h
@@ -49,8 +49,8 @@ class CommandBuffer
     void BeginSingleTake();
     void Draw(const Framebuffer& frameBuffer, const RenderPass& renderPass, const RasterPipeline& pipeline, VertexBuffer& vertexBuffer, const DescriptorSet& descriptorSet);
     void DrawIndexed(const Framebuffer& frameBuffer, const RenderPass& renderPass, const RasterPipeline& pipeline, VertexBuffer& vertexBuffer, IndexBuffer& indexBuffer, const DescriptorSet& descriptorSet);
-    std::shared_ptr<Fence> End(std::span<Semaphore> waitSemaphores, std::span<Semaphore> signalSemaphores);
-    std::shared_ptr<Fence> End();
+    Fence& End(std::span<Semaphore> waitSemaphores, std::span<Semaphore> signalSemaphores);
+    Fence& End();
     void Copy(const DeviceBuffer &source, const DeviceBuffer &destination);
     void CopyBufferToImage(const DeviceBuffer& source, Texture& texture);
     void InsertBarrier(const BufferMemoryBarrier &barrier) const;
@@ -78,7 +78,8 @@ class CommandBuffer
     // better so that End consumes into an executed command buffer,
     // possibly with a recyclable command buffer handle if it wasn't single
     // take
-    std::shared_ptr<Fence> m_InFlight;
+    // Needs to outlive the CommandBuffer in case it's moved
+    std::unique_ptr<Fence> m_InFlight;
     CommandBufferStatus m_Status = CommandBufferStatus::Reset;
     Queue m_Queue;
     std::vector<BufferMemoryBarrierArray> m_PendingBarriers;

--- a/ArtifactVK/backend/IndexBuffer.cpp
+++ b/ArtifactVK/backend/IndexBuffer.cpp
@@ -27,18 +27,18 @@ IndexBuffer::IndexBuffer(CreateIndexBufferInfo bufferInfo, VkDevice device, cons
 	}
 	
 	// TODO: Use semaphore instead, allow fetching the semaphore
-	m_TransferFence = transferCommandBuffer.End({}, {});
+	m_TransferFence = &transferCommandBuffer.End({}, {});
 }
 
 DeviceBuffer& IndexBuffer::GetBuffer()
 {
-    if (m_TransferFence)
+    if (m_TransferFence != nullptr)
     {
-		// TODO: Allow doing this explciitly instead, as we can't read
+		// TODO: Allow doing this explicitly instead, as we can't read
 		// the intent behind calling `Get` this can lead to 
 		// unexpected results
-        m_TransferFence->WaitAndReset();   
-		m_TransferFence.reset();
+        m_TransferFence->WaitAndReset();
+		m_TransferFence = nullptr;
 	}
     return m_IndexBuffer;
 }

--- a/ArtifactVK/backend/IndexBuffer.h
+++ b/ArtifactVK/backend/IndexBuffer.h
@@ -34,5 +34,5 @@ class IndexBuffer
     DeviceBuffer m_IndexBuffer;
     size_t m_IndexCount;
 
-    std::shared_ptr<Fence> m_TransferFence;
+    Fence* m_TransferFence = nullptr;
 };

--- a/ArtifactVK/backend/Texture.cpp
+++ b/ArtifactVK/backend/Texture.cpp
@@ -62,7 +62,7 @@ Texture::Texture(VkDevice device, const PhysicalDevice &physicalDevice, const Te
 
     TransitionLayout(VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                      VkImageLayout::VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, transferCommandBuffer, destinationQueue);
-    m_PendingTransferFence = transferCommandBuffer.End();
+    m_PendingTransferFence = &transferCommandBuffer.End();
 
     VkImageViewCreateInfo viewInfo{};
     viewInfo.sType = VkStructureType::VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -110,7 +110,7 @@ VkImage Texture::Get()
 		// the intent behind calling `Get` this can lead to 
 		// unexpected results
         m_PendingTransferFence->WaitAndReset();   
-		m_PendingTransferFence.reset();
+		m_PendingTransferFence = nullptr;
 	}
     return m_Image;
 }
@@ -124,7 +124,6 @@ uint32_t Texture::GetHeight() const
 {
     return m_Height;
 }
-
 
 std::optional<ImageMemoryBarrier> Texture::TakePendingAcquire()
 {

--- a/ArtifactVK/backend/Texture.h
+++ b/ArtifactVK/backend/Texture.h
@@ -49,7 +49,7 @@ public:
     uint32_t m_Height;
 
     std::optional<ImageMemoryBarrier> m_PendingAcquireBarrier;
-    std::shared_ptr<Fence> m_PendingTransferFence;
+    Fence* m_PendingTransferFence;
     VkImageView m_ImageView;
     VkSampler m_Sampler;
 };

--- a/ArtifactVK/backend/VertexBuffer.cpp
+++ b/ArtifactVK/backend/VertexBuffer.cpp
@@ -15,7 +15,7 @@ DeviceBuffer& VertexBuffer::GetBuffer()
 		// the intent behind calling `Get` this can lead to 
 		// unexpected results
         m_TransferFence->WaitAndReset();   
-		m_TransferFence.reset();
+		m_TransferFence = nullptr;
 	}
     return m_VertexBuffer;
 }

--- a/ArtifactVK/backend/VertexBuffer.h
+++ b/ArtifactVK/backend/VertexBuffer.h
@@ -48,7 +48,7 @@ class VertexBuffer
                 transferCommandBuffer);
         }
         // TODO: Use semaphore instead, allow fetching the semaphore
-        m_TransferFence = transferCommandBuffer.End({}, {});
+        m_TransferFence = &transferCommandBuffer.End({}, {});
     }
 
     size_t VertexCount() const;
@@ -61,5 +61,5 @@ class VertexBuffer
     DeviceBuffer m_StagingBuffer;
     DeviceBuffer m_VertexBuffer;
     size_t m_VertexCount;
-    std::shared_ptr<Fence> m_TransferFence;
+    Fence* m_TransferFence;
 };

--- a/ArtifactVK/backend/VulkanDevice.h
+++ b/ArtifactVK/backend/VulkanDevice.h
@@ -10,6 +10,7 @@
 #include <typeinfo>
 
 #include "DeviceExtensionMapping.h"
+#include "ExtensionFunctionMapping.h"
 #include "VulkanSurface.h"
 #include "Swapchain.h"
 #include "Pipeline.h"
@@ -57,12 +58,16 @@ class VulkanDevice
     void AcquireNext(const Semaphore& toSignal);
     void Present(std::span<Semaphore> waitSemaphores);
     void HandleResizeEvent(const WindowResizeEvent &resizeEvent);
+    ExtensionFunctionMapping GetExtensionFunctionMapping() const;
+
     template<typename T> 
     VertexBuffer &CreateVertexBuffer(std::vector<T> initialData)
     {
         assert(m_GraphicsQueue.has_value() && "Need a graphics queue");
         auto bufferCreateInfo = CreateVertexBufferInfo{initialData, VkSharingMode::VK_SHARING_MODE_EXCLUSIVE, *m_GraphicsQueue };
-        return *m_VertexBuffers.emplace_back(std::make_unique<VertexBuffer>(bufferCreateInfo, m_Device, m_PhysicalDevice, GetTransferCommandBuffer()));
+        auto &commandBuffer = GetTransferCommandBuffer();
+        commandBuffer.SetName("Vertex Buffer Transfer Command Buffer", GetExtensionFunctionMapping());
+        return *m_VertexBuffers.emplace_back(std::make_unique<VertexBuffer>(bufferCreateInfo, m_Device, m_PhysicalDevice, commandBuffer));
     }
 
     IndexBuffer &CreateIndexBuffer(std::vector<uint16_t> data);


### PR DESCRIPTION
Fixes a bug in destroying the command buffer pool, where command buffers could still be in flight. Fixes a validation error.

Also as a drive by improves (temporary) command buffer naming, removes the temp naming that was used, and removes the use of `shared_ptr` on a `Fence`.

The latter is done because it doesn't make sense to have shared ownership of a fence that is associated with a command buffer. It would imply the `CommandBuffer` could be de-allocated prior to the `Fence` being signaled, but this isn't allowed